### PR TITLE
minor change in documentation

### DIFF
--- a/ht/boiling_nucleic.py
+++ b/ht/boiling_nucleic.py
@@ -1122,7 +1122,7 @@ def Zuber(sigma, Hvap, rhol, rhog, K=0.18):
     lists a value of 0.18, and so it is the default.
 
     .. math::
-        q_c = 0.149H_{vap} \rho_g^{0.5}\left[\sigma g (\rho_L-\rho_g)\right]^{0.25}
+        q_c = KH_{vap} \rho_g^{0.5}\left[\sigma g (\rho_L-\rho_g)\right]^{0.25}
 
     Parameters
     ----------


### PR DESCRIPTION
In 'ht.boiling_nucleic.Zuber' function, K is a user input (variable) whose default value is 0.18. Hence, the value 0.149 is changed to K in general.